### PR TITLE
Modify MutableTree and nodeDB in order to avoid all non-preimage key usage

### DIFF
--- a/basic_test.go
+++ b/basic_test.go
@@ -470,7 +470,7 @@ func TestPersistence(t *testing.T) {
 	}
 
 	// Construct some tree and save it
-	t1, err := NewMutableTree(db, 0, false)
+	t1, err := NewMutableTree(db, 0, false, nil, false)
 	require.NoError(t, err)
 	for key, value := range records {
 		t1.Set([]byte(key), []byte(value))
@@ -478,7 +478,7 @@ func TestPersistence(t *testing.T) {
 	t1.SaveVersion()
 
 	// Load a tree
-	t2, err := NewMutableTree(db, 0, false)
+	t2, err := NewMutableTree(db, 0, false, nil, false)
 	require.NoError(t, err)
 	t2.Load()
 	for key, value := range records {
@@ -528,7 +528,7 @@ func TestProof(t *testing.T) {
 
 func TestTreeProof(t *testing.T) {
 	db := db.NewMemDB()
-	tree, err := NewMutableTree(db, 100, false)
+	tree, err := NewMutableTree(db, 100, false, nil, false)
 	require.NoError(t, err)
 	hash, err := tree.Hash()
 	require.NoError(t, err)

--- a/benchmarks/cosmos-exim/main.go
+++ b/benchmarks/cosmos-exim/main.go
@@ -90,7 +90,7 @@ func runExport(dbPath string) (int64, map[string][]*iavl.ExportNode, error) {
 	if err != nil {
 		return 0, nil, err
 	}
-	tree, err := iavl.NewMutableTree(tmdb.NewPrefixDB(ldb, []byte("s/k:main/")), 0, false)
+	tree, err := iavl.NewMutableTree(tmdb.NewPrefixDB(ldb, []byte("s/k:main/")), 0, false, nil, false)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -105,7 +105,7 @@ func runExport(dbPath string) (int64, map[string][]*iavl.ExportNode, error) {
 	totalStats := Stats{}
 	for _, name := range stores {
 		db := tmdb.NewPrefixDB(ldb, []byte("s/k:"+name+"/"))
-		tree, err := iavl.NewMutableTree(db, 0, false)
+		tree, err := iavl.NewMutableTree(db, 0, false, nil, false)
 		if err != nil {
 			return 0, nil, err
 		}
@@ -173,7 +173,7 @@ func runImport(version int64, exports map[string][]*iavl.ExportNode) error {
 		if err != nil {
 			return err
 		}
-		newTree, err := iavl.NewMutableTree(newDB, 0, false)
+		newTree, err := iavl.NewMutableTree(newDB, 0, false, nil, false)
 		if err != nil {
 			return err
 		}

--- a/export_test.go
+++ b/export_test.go
@@ -14,7 +14,7 @@ import (
 // setupExportTreeBasic sets up a basic tree with a handful of
 // create/update/delete operations over a few versions.
 func setupExportTreeBasic(t require.TestingT) *ImmutableTree {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 	require.NoError(t, err)
 
 	_, err = tree.Set([]byte("x"), []byte{255})
@@ -72,7 +72,7 @@ func setupExportTreeRandom(t *testing.T) *ImmutableTree {
 	)
 
 	r := rand.New(rand.NewSource(randSeed))
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 	require.NoError(t, err)
 
 	var version int64
@@ -132,7 +132,7 @@ func setupExportTreeSized(t require.TestingT, treeSize int) *ImmutableTree { //n
 	)
 
 	r := rand.New(rand.NewSource(randSeed))
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 	require.NoError(t, err)
 
 	for i := 0; i < treeSize; i++ {
@@ -190,7 +190,7 @@ func TestExporter(t *testing.T) {
 
 func TestExporter_Import(t *testing.T) {
 	testcases := map[string]*ImmutableTree{
-		"empty tree": NewImmutableTree(db.NewMemDB(), 0, false),
+		"empty tree": NewImmutableTree(db.NewMemDB(), 0, false, false),
 		"basic tree": setupExportTreeBasic(t),
 	}
 	if !testing.Short() {
@@ -207,7 +207,7 @@ func TestExporter_Import(t *testing.T) {
 			require.NoError(t, err)
 			defer exporter.Close()
 
-			newTree, err := NewMutableTree(db.NewMemDB(), 0, false)
+			newTree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 			require.NoError(t, err)
 			importer, err := newTree.Import(tree.Version())
 			require.NoError(t, err)
@@ -272,7 +272,7 @@ func TestExporter_Close(t *testing.T) {
 }
 
 func TestExporter_DeleteVersionErrors(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 	require.NoError(t, err)
 
 	_, err = tree.Set([]byte("a"), []byte{1})

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -21,23 +21,23 @@ type ImmutableTree struct {
 }
 
 // NewImmutableTree creates both in-memory and persistent instances
-func NewImmutableTree(db dbm.DB, cacheSize int, skipFastStorageUpgrade bool) *ImmutableTree {
+func NewImmutableTree(db dbm.DB, cacheSize int, skipFastStorageUpgrade bool, noStoreVersion bool) *ImmutableTree {
 	if db == nil {
 		// In-memory Tree.
 		return &ImmutableTree{}
 	}
 	return &ImmutableTree{
 		// NodeDB-backed Tree.
-		ndb:                    newNodeDB(db, cacheSize, nil),
+		ndb:                    newNodeDB(db, cacheSize, nil, noStoreVersion),
 		skipFastStorageUpgrade: skipFastStorageUpgrade,
 	}
 }
 
 // NewImmutableTreeWithOpts creates an ImmutableTree with the given options.
-func NewImmutableTreeWithOpts(db dbm.DB, cacheSize int, opts *Options, skipFastStorageUpgrade bool) *ImmutableTree {
+func NewImmutableTreeWithOpts(db dbm.DB, cacheSize int, opts *Options, skipFastStorageUpgrade bool, noStoreVersion bool) *ImmutableTree {
 	return &ImmutableTree{
 		// NodeDB-backed Tree.
-		ndb:                    newNodeDB(db, cacheSize, opts),
+		ndb:                    newNodeDB(db, cacheSize, opts, noStoreVersion),
 		skipFastStorageUpgrade: skipFastStorageUpgrade,
 	}
 }

--- a/import_test.go
+++ b/import_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ExampleImporter() {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 	if err != nil {
 		// handle err
 	}
@@ -54,7 +54,7 @@ func ExampleImporter() {
 		exported = append(exported, node)
 	}
 
-	newTree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	newTree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 	if err != nil {
 		// handle err
 	}
@@ -76,14 +76,14 @@ func ExampleImporter() {
 }
 
 func TestImporter_NegativeVersion(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 	require.NoError(t, err)
 	_, err = tree.Import(-1)
 	require.Error(t, err)
 }
 
 func TestImporter_NotEmpty(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 	require.NoError(t, err)
 	_, err = tree.Set([]byte("a"), []byte{1})
 	require.NoError(t, err)
@@ -97,14 +97,14 @@ func TestImporter_NotEmpty(t *testing.T) {
 func TestImporter_NotEmptyDatabase(t *testing.T) {
 	db := db.NewMemDB()
 
-	tree, err := NewMutableTree(db, 0, false)
+	tree, err := NewMutableTree(db, 0, false, nil, false)
 	require.NoError(t, err)
 	_, err = tree.Set([]byte("a"), []byte{1})
 	require.NoError(t, err)
 	_, _, err = tree.SaveVersion()
 	require.NoError(t, err)
 
-	tree, err = NewMutableTree(db, 0, false)
+	tree, err = NewMutableTree(db, 0, false, nil, false)
 	require.NoError(t, err)
 	_, err = tree.Load()
 	require.NoError(t, err)
@@ -114,7 +114,7 @@ func TestImporter_NotEmptyDatabase(t *testing.T) {
 }
 
 func TestImporter_NotEmptyUnsaved(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 	require.NoError(t, err)
 	_, err = tree.Set([]byte("a"), []byte{1})
 	require.NoError(t, err)
@@ -142,7 +142,7 @@ func TestImporter_Add(t *testing.T) {
 	for desc, tc := range testcases {
 		tc := tc // appease scopelint
 		t.Run(desc, func(t *testing.T) {
-			tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+			tree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 			require.NoError(t, err)
 			importer, err := tree.Import(1)
 			require.NoError(t, err)
@@ -159,7 +159,7 @@ func TestImporter_Add(t *testing.T) {
 }
 
 func TestImporter_Add_Closed(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 	require.NoError(t, err)
 	importer, err := tree.Import(1)
 	require.NoError(t, err)
@@ -171,7 +171,7 @@ func TestImporter_Add_Closed(t *testing.T) {
 }
 
 func TestImporter_Close(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 	require.NoError(t, err)
 	importer, err := tree.Import(1)
 	require.NoError(t, err)
@@ -188,7 +188,7 @@ func TestImporter_Close(t *testing.T) {
 }
 
 func TestImporter_Commit(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 	require.NoError(t, err)
 	importer, err := tree.Import(1)
 	require.NoError(t, err)
@@ -204,7 +204,7 @@ func TestImporter_Commit(t *testing.T) {
 }
 
 func TestImporter_Commit_Closed(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 	require.NoError(t, err)
 	importer, err := tree.Import(1)
 	require.NoError(t, err)
@@ -219,7 +219,7 @@ func TestImporter_Commit_Closed(t *testing.T) {
 }
 
 func TestImporter_Commit_Empty(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 	require.NoError(t, err)
 	importer, err := tree.Import(3)
 	require.NoError(t, err)
@@ -249,7 +249,7 @@ func BenchmarkImport(b *testing.B) {
 	b.StartTimer()
 
 	for n := 0; n < b.N; n++ {
-		newTree, err := NewMutableTree(db.NewMemDB(), 0, false)
+		newTree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 		require.NoError(b, err)
 		importer, err := newTree.Import(tree.Version())
 		require.NoError(b, err)

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -56,7 +56,7 @@ func TestUnsavedFastIterator_NewIterator_NilAdditions_Failure(t *testing.T) {
 	}
 
 	t.Run("Nil additions given", func(t *testing.T) {
-		tree, err := NewMutableTree(dbm.NewMemDB(), 0, false)
+		tree, err := NewMutableTree(dbm.NewMemDB(), 0, false, nil, false)
 		require.NoError(t, err)
 		itr := NewUnsavedFastIterator(start, end, ascending, tree.ndb, nil, tree.unsavedFastNodeRemovals)
 		performTest(t, itr)
@@ -64,7 +64,7 @@ func TestUnsavedFastIterator_NewIterator_NilAdditions_Failure(t *testing.T) {
 	})
 
 	t.Run("Nil removals given", func(t *testing.T) {
-		tree, err := NewMutableTree(dbm.NewMemDB(), 0, false)
+		tree, err := NewMutableTree(dbm.NewMemDB(), 0, false, nil, false)
 		require.NoError(t, err)
 		itr := NewUnsavedFastIterator(start, end, ascending, tree.ndb, tree.unsavedFastNodeAdditions, nil)
 		performTest(t, itr)
@@ -78,7 +78,7 @@ func TestUnsavedFastIterator_NewIterator_NilAdditions_Failure(t *testing.T) {
 	})
 
 	t.Run("Additions and removals are nil", func(t *testing.T) {
-		tree, err := NewMutableTree(dbm.NewMemDB(), 0, false)
+		tree, err := NewMutableTree(dbm.NewMemDB(), 0, false, nil, false)
 		require.NoError(t, err)
 		itr := NewUnsavedFastIterator(start, end, ascending, tree.ndb, nil, nil)
 		performTest(t, itr)
@@ -248,7 +248,7 @@ func iteratorSuccessTest(t *testing.T, config *iteratorTestConfig) {
 }
 
 func setupIteratorAndMirror(t *testing.T, config *iteratorTestConfig) (dbm.Iterator, [][]string) {
-	tree, err := NewMutableTree(dbm.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(dbm.NewMemDB(), 0, false, nil, false)
 	require.NoError(t, err)
 
 	mirror := setupMirrorForIterator(t, config, tree)
@@ -265,7 +265,7 @@ func setupIteratorAndMirror(t *testing.T, config *iteratorTestConfig) (dbm.Itera
 }
 
 func setupFastIteratorAndMirror(t *testing.T, config *iteratorTestConfig) (dbm.Iterator, [][]string) {
-	tree, err := NewMutableTree(dbm.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(dbm.NewMemDB(), 0, false, nil, false)
 	require.NoError(t, err)
 
 	mirror := setupMirrorForIterator(t, config, tree)
@@ -277,7 +277,7 @@ func setupFastIteratorAndMirror(t *testing.T, config *iteratorTestConfig) (dbm.I
 }
 
 func setupUnsavedFastIterator(t *testing.T, config *iteratorTestConfig) (dbm.Iterator, [][]string) {
-	tree, err := NewMutableTree(dbm.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(dbm.NewMemDB(), 0, false, nil, false)
 	require.NoError(t, err)
 
 	// For unsaved fast iterator, we would like to test the state where

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -820,13 +820,9 @@ func (tree *MutableTree) enableFastStorageAndCommit() error {
 // GetImmutable loads an ImmutableTree at a given version for querying. The returned tree is
 // safe for concurrent access, provided the version is not deleted, e.g. via `DeleteVersion()`.
 func (tree *MutableTree) GetImmutable(version int64) (*ImmutableTree, error) {
-	rootHash := tree.rootHash
-	var err error
-	if rootHash != nil {
-		rootHash, err = tree.ndb.getRoot(version)
-		if err != nil {
-			return nil, err
-		}
+	rootHash, err := tree.ndb.getRoot(version)
+	if err != nil {
+		return nil, err
 	}
 	if rootHash == nil {
 		return nil, ErrVersionDoesNotExist
@@ -920,13 +916,9 @@ func (tree *MutableTree) SaveVersion() ([]byte, int64, error) {
 	if tree.VersionExists(version) {
 		// If the version already exists, return an error as we're attempting to overwrite.
 		// However, the same hash means idempotent (i.e. no-op).
-		existingHash := tree.rootHash
-		var err error
-		if existingHash == nil {
-			existingHash, err = tree.ndb.getRoot(version)
-			if err != nil {
-				return nil, version, err
-			}
+		existingHash, err := tree.ndb.getRoot(version)
+		if err != nil {
+			return nil, version, err
 		}
 
 		// If the existing root hash is empty (because the tree is empty), then we need to

--- a/nodedb.go
+++ b/nodedb.go
@@ -83,15 +83,19 @@ type nodeDB struct {
 	fastNodeCache  cache.Cache      // Cache for nodes in the fast index that represents only key-value pairs at the latest version.
 }
 
-func newNodeDB(db dbm.DB, cacheSize int, opts *Options) *nodeDB {
+func newNodeDB(db dbm.DB, cacheSize int, opts *Options, noStoreVersion bool) *nodeDB {
 	if opts == nil {
 		o := DefaultOptions()
 		opts = &o
 	}
 
-	storeVersion, err := db.Get(metadataKeyFormat.Key(ibytes.UnsafeStrToBytes(storageVersionKey)))
-
-	if err != nil || storeVersion == nil {
+	var storeVersion []byte
+	if !noStoreVersion {
+		storeVersion, err := db.Get(metadataKeyFormat.Key(ibytes.UnsafeStrToBytes(storageVersionKey)))
+		if err != nil || storeVersion == nil {
+			storeVersion = []byte(defaultStorageVersionValue)
+		}
+	} else {
 		storeVersion = []byte(defaultStorageVersionValue)
 	}
 

--- a/nodedb.go
+++ b/nodedb.go
@@ -91,7 +91,8 @@ func newNodeDB(db dbm.DB, cacheSize int, opts *Options, noStoreVersion bool) *no
 
 	var storeVersion []byte
 	if !noStoreVersion {
-		storeVersion, err := db.Get(metadataKeyFormat.Key(ibytes.UnsafeStrToBytes(storageVersionKey)))
+		var err error
+		storeVersion, err = db.Get(metadataKeyFormat.Key(ibytes.UnsafeStrToBytes(storageVersionKey)))
 		if err != nil || storeVersion == nil {
 			storeVersion = []byte(defaultStorageVersionValue)
 		}

--- a/proof_iavl_test.go
+++ b/proof_iavl_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestProofOp(t *testing.T) {
-	tree, err := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil, false)
+	tree, err := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil, false, nil, false)
 	require.NoError(t, err)
 	keys := []byte{0x0a, 0x11, 0x2e, 0x32, 0x50, 0x72, 0x99, 0xa1, 0xe4, 0xf7} // 10 total.
 	for _, ikey := range keys {

--- a/proof_ics23_test.go
+++ b/proof_ics23_test.go
@@ -205,7 +205,7 @@ func GetNonKey(allkeys [][]byte, loc Where) []byte {
 // BuildTree creates random key/values and stores in tree
 // returns a list of all keys in sorted order
 func BuildTree(size int, cacheSize int) (itree *MutableTree, keys [][]byte, err error) {
-	tree, err := NewMutableTree(db.NewMemDB(), cacheSize, false)
+	tree, err := NewMutableTree(db.NewMemDB(), cacheSize, false, nil, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -42,7 +42,7 @@ func b2i(bz []byte) int {
 
 // Construct a MutableTree
 func getTestTree(cacheSize int) (*MutableTree, error) {
-	return NewMutableTreeWithOpts(db.NewMemDB(), cacheSize, nil, false)
+	return NewMutableTreeWithOpts(db.NewMemDB(), cacheSize, nil, false, nil, false)
 }
 
 // Convenience for a new node
@@ -323,7 +323,7 @@ func benchmarkImmutableAvlTreeWithDB(b *testing.B, db db.DB) {
 
 	b.StopTimer()
 
-	t, err := NewMutableTree(db, 100000, false)
+	t, err := NewMutableTree(db, 100000, false, nil, false)
 	require.NoError(b, err)
 
 	value := []byte{}

--- a/tree_random_test.go
+++ b/tree_random_test.go
@@ -82,7 +82,7 @@ func testRandomOperations(t *testing.T, randSeed int64) {
 		if !(r.Float64() < cacheChance) {
 			cacheSize = 0
 		}
-		tree, err = NewMutableTreeWithOpts(levelDB, cacheSize, options, false)
+		tree, err = NewMutableTreeWithOpts(levelDB, cacheSize, options, false, nil, false)
 		require.NoError(t, err)
 		version, err = tree.Load()
 		require.NoError(t, err)

--- a/tree_test.go
+++ b/tree_test.go
@@ -53,7 +53,7 @@ func TestVersionedRandomTree(t *testing.T) {
 	d, closeDB := getTestDB()
 	defer closeDB()
 
-	tree, err := NewMutableTree(d, 100, false)
+	tree, err := NewMutableTree(d, 100, false, nil, false)
 	require.NoError(err)
 	versions := 50
 	keysPerVersion := 30
@@ -135,7 +135,7 @@ func TestTreeHash(t *testing.T) {
 	require.Len(t, expectHashes, versions, "must have expected hashes for all versions")
 
 	r := rand.New(rand.NewSource(randSeed))
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 	require.NoError(t, err)
 
 	keys := make([][]byte, 0, versionOps)
@@ -186,7 +186,7 @@ func TestVersionedRandomTreeSmallKeys(t *testing.T) {
 	d, closeDB := getTestDB()
 	defer closeDB()
 
-	tree, err := NewMutableTree(d, 100, false)
+	tree, err := NewMutableTree(d, 100, false, nil, false)
 	require.NoError(err)
 	singleVersionTree, err := getTestTree(0)
 	require.NoError(err)
@@ -236,7 +236,7 @@ func TestVersionedRandomTreeSmallKeysRandomDeletes(t *testing.T) {
 	d, closeDB := getTestDB()
 	defer closeDB()
 
-	tree, err := NewMutableTree(d, 100, false)
+	tree, err := NewMutableTree(d, 100, false, nil, false)
 	require.NoError(err)
 	singleVersionTree, err := getTestTree(0)
 	require.NoError(err)
@@ -331,7 +331,7 @@ func TestVersionedEmptyTree(t *testing.T) {
 	d, closeDB := getTestDB()
 	defer closeDB()
 
-	tree, err := NewMutableTree(d, 0, false)
+	tree, err := NewMutableTree(d, 0, false, nil, false)
 	require.NoError(err)
 
 	hash, v, err := tree.SaveVersion()
@@ -370,7 +370,7 @@ func TestVersionedEmptyTree(t *testing.T) {
 
 	// Now reload the tree.
 
-	tree, err = NewMutableTree(d, 0, false)
+	tree, err = NewMutableTree(d, 0, false, nil, false)
 	require.NoError(err)
 	tree.Load()
 
@@ -389,7 +389,7 @@ func TestVersionedTree(t *testing.T) {
 	d, closeDB := getTestDB()
 	defer closeDB()
 
-	tree, err := NewMutableTree(d, 0, false)
+	tree, err := NewMutableTree(d, 0, false, nil, false)
 	require.NoError(err)
 
 	// We start with empty database.
@@ -440,7 +440,7 @@ func TestVersionedTree(t *testing.T) {
 
 	// Recreate a new tree and load it, to make sure it works in this
 	// scenario.
-	tree, err = NewMutableTree(d, 100, false)
+	tree, err = NewMutableTree(d, 100, false, nil, false)
 	require.NoError(err)
 	_, err = tree.Load()
 	require.NoError(err)
@@ -494,7 +494,7 @@ func TestVersionedTree(t *testing.T) {
 	require.EqualValues(hash3, hash4)
 	require.NotNil(hash4)
 
-	tree, err = NewMutableTree(d, 100, false)
+	tree, err = NewMutableTree(d, 100, false, nil, false)
 	require.NoError(err)
 	_, err = tree.Load()
 	require.NoError(err)
@@ -611,7 +611,7 @@ func TestVersionedTreeVersionDeletingEfficiency(t *testing.T) {
 	d, closeDB := getTestDB()
 	defer closeDB()
 
-	tree, err := NewMutableTree(d, 0, false)
+	tree, err := NewMutableTree(d, 0, false, nil, false)
 	require.NoError(t, err)
 
 	tree.Set([]byte("key0"), []byte("val0"))
@@ -712,7 +712,7 @@ func TestVersionedTreeSpecialCase(t *testing.T) {
 	d, closeDB := getTestDB()
 	defer closeDB()
 
-	tree, err := NewMutableTree(d, 0, false)
+	tree, err := NewMutableTree(d, 0, false, nil, false)
 	require.NoError(err)
 
 	tree.Set([]byte("key1"), []byte("val0"))
@@ -737,7 +737,7 @@ func TestVersionedTreeSpecialCase2(t *testing.T) {
 	require := require.New(t)
 
 	d := db.NewMemDB()
-	tree, err := NewMutableTree(d, 100, false)
+	tree, err := NewMutableTree(d, 100, false, nil, false)
 	require.NoError(err)
 
 	tree.Set([]byte("key1"), []byte("val0"))
@@ -751,7 +751,7 @@ func TestVersionedTreeSpecialCase2(t *testing.T) {
 	tree.Set([]byte("key2"), []byte("val2"))
 	tree.SaveVersion()
 
-	tree, err = NewMutableTree(d, 100, false)
+	tree, err = NewMutableTree(d, 100, false, nil, false)
 	require.NoError(err)
 	_, err = tree.Load()
 	require.NoError(err)
@@ -797,7 +797,7 @@ func TestVersionedTreeSpecialCase3(t *testing.T) {
 func TestVersionedTreeSaveAndLoad(t *testing.T) {
 	require := require.New(t)
 	d := db.NewMemDB()
-	tree, err := NewMutableTree(d, 0, false)
+	tree, err := NewMutableTree(d, 0, false, nil, false)
 	require.NoError(err)
 
 	// Loading with an empty root is a no-op.
@@ -823,7 +823,7 @@ func TestVersionedTreeSaveAndLoad(t *testing.T) {
 	require.Equal(int64(6), tree.Version())
 
 	// Reload the tree, to test that roots and orphans are properly loaded.
-	ntree, err := NewMutableTree(d, 0, false)
+	ntree, err := NewMutableTree(d, 0, false, nil, false)
 	require.NoError(err)
 	ntree.Load()
 
@@ -885,7 +885,7 @@ func TestVersionedCheckpoints(t *testing.T) {
 	d, closeDB := getTestDB()
 	defer closeDB()
 
-	tree, err := NewMutableTree(d, 100, false)
+	tree, err := NewMutableTree(d, 100, false, nil, false)
 	require.NoError(err)
 	versions := 50
 	keysPerVersion := 10
@@ -1013,7 +1013,7 @@ func TestVersionedCheckpointsSpecialCase3(t *testing.T) {
 }
 
 func TestVersionedCheckpointsSpecialCase4(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 	require.NoError(t, err)
 
 	tree.Set([]byte("U"), []byte("XamDUtiJ"))
@@ -1136,7 +1136,7 @@ func TestVersionedCheckpointsSpecialCase7(t *testing.T) {
 
 func TestVersionedTreeEfficiency(t *testing.T) {
 	require := require.New(t)
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0, false, nil, false)
 	require.NoError(err)
 	versions := 20
 	keysPerVersion := 100
@@ -1269,7 +1269,7 @@ func TestOrphans(t *testing.T) {
 	// Then randomly delete versions other than the first and last until only those two remain
 	// Any remaining orphan nodes should either have fromVersion == firstVersion || toVersion == lastVersion
 	require := require.New(t)
-	tree, err := NewMutableTree(db.NewMemDB(), 100, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 100, false, nil, false)
 	require.NoError(err)
 
 	NUMVERSIONS := 100
@@ -1439,7 +1439,7 @@ func TestOverwrite(t *testing.T) {
 	require := require.New(t)
 
 	mdb := db.NewMemDB()
-	tree, err := NewMutableTree(mdb, 0, false)
+	tree, err := NewMutableTree(mdb, 0, false, nil, false)
 	require.NoError(err)
 
 	// Set one kv pair and save version 1
@@ -1453,7 +1453,7 @@ func TestOverwrite(t *testing.T) {
 	require.NoError(err, "SaveVersion should not fail")
 
 	// Reload tree at version 1
-	tree, err = NewMutableTree(mdb, 0, false)
+	tree, err = NewMutableTree(mdb, 0, false, nil, false)
 	require.NoError(err)
 	_, err = tree.LoadVersion(int64(1))
 	require.NoError(err, "LoadVersion should not fail")
@@ -1473,7 +1473,7 @@ func TestOverwriteEmpty(t *testing.T) {
 	require := require.New(t)
 
 	mdb := db.NewMemDB()
-	tree, err := NewMutableTree(mdb, 0, false)
+	tree, err := NewMutableTree(mdb, 0, false, nil, false)
 	require.NoError(err)
 
 	// Save empty version 1
@@ -1508,7 +1508,7 @@ func TestLoadVersionForOverwriting(t *testing.T) {
 	require := require.New(t)
 
 	mdb := db.NewMemDB()
-	tree, err := NewMutableTree(mdb, 0, false)
+	tree, err := NewMutableTree(mdb, 0, false, nil, false)
 	require.NoError(err)
 
 	maxLength := 100
@@ -1520,12 +1520,12 @@ func TestLoadVersionForOverwriting(t *testing.T) {
 		require.NoError(err, "SaveVersion should not fail")
 	}
 
-	tree, err = NewMutableTree(mdb, 0, false)
+	tree, err = NewMutableTree(mdb, 0, false, nil, false)
 	require.NoError(err)
 	targetVersion, _ := tree.LoadVersionForOverwriting(int64(maxLength * 2))
 	require.Equal(targetVersion, int64(maxLength), "targetVersion shouldn't larger than the actual tree latest version")
 
-	tree, err = NewMutableTree(mdb, 0, false)
+	tree, err = NewMutableTree(mdb, 0, false, nil, false)
 	require.NoError(err)
 	_, err = tree.LoadVersionForOverwriting(int64(maxLength / 2))
 	require.NoError(err, "LoadVersion should not fail")
@@ -1549,7 +1549,7 @@ func TestLoadVersionForOverwriting(t *testing.T) {
 	require.NoError(err, "SaveVersion should not fail, overwrite was allowed")
 
 	// Reload tree at version 50, the latest tree version is 52
-	tree, err = NewMutableTree(mdb, 0, false)
+	tree, err = NewMutableTree(mdb, 0, false, nil, false)
 	require.NoError(err)
 	_, err = tree.LoadVersion(int64(maxLength / 2))
 	require.NoError(err, "LoadVersion should not fail")
@@ -1582,7 +1582,7 @@ func TestDeleteVersionsCompare(t *testing.T) {
 	const fromLength = 5
 	{
 		mdb := db.NewMemDB()
-		tree, err := NewMutableTree(mdb, 0, false)
+		tree, err := NewMutableTree(mdb, 0, false, nil, false)
 		require.NoError(err)
 
 		versions := make([]int64, 0, maxLength)
@@ -1596,7 +1596,7 @@ func TestDeleteVersionsCompare(t *testing.T) {
 			require.NoError(err, "SaveVersion should not fail")
 		}
 
-		tree, err = NewMutableTree(mdb, 0, false)
+		tree, err = NewMutableTree(mdb, 0, false, nil, false)
 		require.NoError(err)
 		targetVersion, err := tree.LoadVersion(int64(maxLength))
 		require.NoError(err)
@@ -1609,7 +1609,7 @@ func TestDeleteVersionsCompare(t *testing.T) {
 	}
 	{
 		mdb := db.NewMemDB()
-		tree, err := NewMutableTree(mdb, 0, false)
+		tree, err := NewMutableTree(mdb, 0, false, nil, false)
 		require.NoError(err)
 
 		versions := make([]int64, 0, maxLength)
@@ -1623,7 +1623,7 @@ func TestDeleteVersionsCompare(t *testing.T) {
 			require.NoError(err, "SaveVersion should not fail")
 		}
 
-		tree, err = NewMutableTree(mdb, 0, false)
+		tree, err = NewMutableTree(mdb, 0, false, nil, false)
 		require.NoError(err)
 		targetVersion, err := tree.LoadVersion(int64(maxLength))
 		require.NoError(err)
@@ -1638,7 +1638,7 @@ func TestDeleteVersionsCompare(t *testing.T) {
 	}
 	{
 		mdb := db.NewMemDB()
-		tree, err := NewMutableTree(mdb, 0, false)
+		tree, err := NewMutableTree(mdb, 0, false, nil, false)
 		require.NoError(err)
 
 		versions := make([]int64, 0, maxLength)
@@ -1652,7 +1652,7 @@ func TestDeleteVersionsCompare(t *testing.T) {
 			require.NoError(err, "SaveVersion should not fail")
 		}
 
-		tree, err = NewMutableTree(mdb, 0, false)
+		tree, err = NewMutableTree(mdb, 0, false, nil, false)
 		require.NoError(err)
 		targetVersion, err := tree.LoadVersion(int64(maxLength))
 		require.NoError(err)
@@ -1681,7 +1681,7 @@ func BenchmarkTreeLoadAndDelete(b *testing.B) {
 	defer d.Close()
 	defer os.RemoveAll("./bench.db")
 
-	tree, err := NewMutableTree(d, 0, false)
+	tree, err := NewMutableTree(d, 0, false, nil, false)
 	require.NoError(b, err)
 	for v := 1; v < numVersions; v++ {
 		for i := 0; i < numKeysPerVersion; i++ {
@@ -1693,7 +1693,7 @@ func BenchmarkTreeLoadAndDelete(b *testing.B) {
 	b.Run("LoadAndDelete", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			b.StopTimer()
-			tree, err = NewMutableTree(d, 0, false)
+			tree, err = NewMutableTree(d, 0, false, nil, false)
 			require.NoError(b, err)
 			runtime.GC()
 			b.StartTimer()
@@ -1717,7 +1717,7 @@ func BenchmarkTreeLoadAndDelete(b *testing.B) {
 func TestLoadVersionForOverwritingCase2(t *testing.T) {
 	require := require.New(t)
 
-	tree, _ := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil, false)
+	tree, _ := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil, false, nil, false)
 
 	for i := byte(0); i < 20; i++ {
 		tree.Set([]byte{i}, []byte{i})
@@ -1779,7 +1779,7 @@ func TestLoadVersionForOverwritingCase2(t *testing.T) {
 func TestLoadVersionForOverwritingCase3(t *testing.T) {
 	require := require.New(t)
 
-	tree, err := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil, false)
+	tree, err := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil, false, nil, false)
 	require.NoError(err)
 
 	for i := byte(0); i < 20; i++ {
@@ -1910,7 +1910,7 @@ func Benchmark_GetWithIndex(b *testing.B) {
 
 	const numKeyVals = 100000
 
-	t, err := NewMutableTree(db, numKeyVals, false)
+	t, err := NewMutableTree(db, numKeyVals, false, nil, false)
 	require.NoError(b, err)
 
 	keys := make([][]byte, 0, numKeyVals)
@@ -1962,7 +1962,7 @@ func Benchmark_GetByIndex(b *testing.B) {
 
 	const numKeyVals = 100000
 
-	t, err := NewMutableTree(db, numKeyVals, false)
+	t, err := NewMutableTree(db, numKeyVals, false, nil, false)
 	require.NoError(b, err)
 
 	for i := 0; i < numKeyVals; i++ {
@@ -2038,7 +2038,7 @@ func TestNodeCacheStatisic(t *testing.T) {
 			opts := &Options{Stat: stat}
 			db, err := db.NewDB("test", db.MemDBBackend, "")
 			require.NoError(t, err)
-			mt, err := NewMutableTreeWithOpts(db, tc.cacheSize, opts, false)
+			mt, err := NewMutableTreeWithOpts(db, tc.cacheSize, opts, false, nil, false)
 			require.NoError(t, err)
 
 			for i := 0; i < numKeyVals; i++ {


### PR DESCRIPTION
* For https://github.com/polymerdao/roadmap/issues/25
* On-top of the v0.20.0 version we use in Polymerase

Non-preimage keys were being used in two places (even in this legacy format):
1. To lookup the root hash by version (block height), which is then used to retrieve the root node. We need to instead provide the roothash directly. This will also require modification in the calling context of our FPP application logic.
2. To load the storage version value (a versioning of the database- not the block height- e.g. 1.1.0).

Note that in our FPP we must also be sure to instantiate our mutable tree without a fastcache, as the fastcache uses non-preimage keys. 

These changes do not affect the underlying DB layout so will be compatible with the normal usage in our non-FPP application logic (Polymerase).