### PR TITLE
feat: Modify v1 IAVL to work with pure-preimage queries

### DIFF
--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -348,7 +348,6 @@ func runBenchmarks(b *testing.B, benchmarks []benchmark) {
 		)
 		if bb.dbType != "nodb" {
 			d, err = dbm.NewDB("test", bb.dbType, dirName)
-
 			if err != nil {
 				if strings.Contains(err.Error(), "unknown db_backend") {
 					// As an exception to run benchmarks: if the error is about cleveldb, or rocksdb,

--- a/import.go
+++ b/import.go
@@ -68,15 +68,27 @@ func (i *Importer) writeNode(node *Node) error {
 	buf.Reset()
 	defer bufPool.Put(buf)
 
-	if err := node.writeBytes(buf); err != nil {
-		return err
+	if i.tree.useLegacyFormat {
+		if err := node.writeLegacyBytes(buf); err != nil {
+			return err
+		}
+	} else {
+		if err := node.writeBytes(buf); err != nil {
+			return err
+		}
 	}
 
 	bytesCopy := make([]byte, buf.Len())
 	copy(bytesCopy, buf.Bytes())
 
-	if err := i.batch.Set(i.tree.ndb.nodeKey(node.GetKey()), bytesCopy); err != nil {
-		return err
+	if i.tree.useLegacyFormat {
+		if err := i.batch.Set(i.tree.ndb.legacyNodeKey(node.GetKey()), bytesCopy); err != nil {
+			return err
+		}
+	} else {
+		if err := i.batch.Set(i.tree.ndb.nodeKey(node.GetKey()), bytesCopy); err != nil {
+			return err
+		}
 	}
 
 	i.batchSize++

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -69,7 +69,8 @@ func NewMutableTree(db dbm.DB, cacheSize int, skipFastStorageUpgrade bool, lg lo
 }
 
 func NewLegacyMutableTree(db dbm.DB, cacheSize int, skipFastStorageUpgrade, noStoreVersion bool,
-	rootHash []byte, lg log.Logger, options ...Option) *MutableTree {
+	rootHash []byte, lg log.Logger, options ...Option,
+) *MutableTree {
 	opts := DefaultOptions()
 	for _, opt := range options {
 		opt(&opts)

--- a/node.go
+++ b/node.go
@@ -77,12 +77,13 @@ type Node struct {
 var _ cache.Node = (*Node)(nil)
 
 // NewNode returns a new node from a key, value and version.
-func NewNode(key []byte, value []byte) *Node {
+func NewNode(key []byte, value []byte, useLegacy bool) *Node {
 	return &Node{
 		key:           key,
 		value:         value,
 		subtreeHeight: 0,
 		size:          1,
+		isLegacy:      useLegacy,
 	}
 }
 
@@ -243,11 +244,9 @@ func MakeLegacyNode(hash, buf []byte) (*Node, error) {
 		nodeKey:       &NodeKey{version: ver},
 		key:           key,
 		hash:          hash,
-		isLegacy:      true,
 	}
 
 	// Read node body.
-
 	if node.isLeaf() {
 		val, _, err := encoding.DecodeBytes(buf)
 		if err != nil {
@@ -268,6 +267,7 @@ func MakeLegacyNode(hash, buf []byte) (*Node, error) {
 		node.leftNodeKey = leftHash
 		node.rightNodeKey = rightHash
 	}
+	//fmt.Printf("legacy node: %+v\r\n", *node)
 	return node, nil
 }
 
@@ -612,6 +612,9 @@ func (node *Node) writeBytes(w io.Writer) error {
 		if node.leftNodeKey == nil {
 			return ErrLeftNodeKeyEmpty
 		}
+		if node.rightNodeKey == nil {
+			return ErrRightNodeKeyEmpty
+		}
 		// check if children NodeKeys are legacy mode
 		if len(node.leftNodeKey) == hashSize {
 			mode += ModeLegacyLeftNode
@@ -657,6 +660,54 @@ func (node *Node) writeBytes(w io.Writer) error {
 			if err != nil {
 				return fmt.Errorf("writing the nonce of right node key, %w", err)
 			}
+		}
+	}
+	return nil
+}
+
+func (node *Node) writeLegacyBytes(w io.Writer) error {
+	if node == nil {
+		return errors.New("cannot write nil node")
+	}
+	err := encoding.EncodeVarint(w, int64(node.subtreeHeight))
+	if err != nil {
+		return fmt.Errorf("writing height, %w", err)
+	}
+	err = encoding.EncodeVarint(w, node.size)
+	if err != nil {
+		return fmt.Errorf("writing size, %w", err)
+	}
+	err = encoding.EncodeVarint(w, node.nodeKey.version)
+	if err != nil {
+		return fmt.Errorf("writing version, %w", err)
+	}
+
+	// Unlike writeHashBytes, key is written for inner nodes.
+	err = encoding.EncodeBytes(w, node.key)
+	if err != nil {
+		return fmt.Errorf("writing key, %w", err)
+	}
+
+	if node.isLeaf() {
+		err = encoding.EncodeBytes(w, node.value)
+		if err != nil {
+			return fmt.Errorf("writing value, %w", err)
+		}
+	} else {
+		if len(node.leftNodeKey) != hashSize {
+			return errors.New("node provided to writeLegacyBytes does not have a hash for leftNodeKey")
+		}
+		err = encoding.EncodeBytes(w, node.leftNodeKey)
+		if err != nil {
+			return fmt.Errorf("writing left hash, %w", err)
+		}
+
+		if len(node.leftNodeKey) != 32 {
+			return errors.New("node provided to writeLegacyBytes does not have a hash for rightNodeKey")
+		}
+		err = encoding.EncodeBytes(w, node.rightNodeKey)
+		if err != nil {
+			return fmt.Errorf("writing right hash, %w", err)
 		}
 	}
 	return nil

--- a/node.go
+++ b/node.go
@@ -267,7 +267,6 @@ func MakeLegacyNode(hash, buf []byte) (*Node, error) {
 		node.leftNodeKey = leftHash
 		node.rightNodeKey = rightHash
 	}
-	//fmt.Printf("legacy node: %+v\r\n", *node)
 	return node, nil
 }
 

--- a/nodedb.go
+++ b/nodedb.go
@@ -876,7 +876,7 @@ func (ndb *nodeDB) SaveRoot(version int64, nk *NodeKey) error {
 func (ndb *nodeDB) SaveLegacyRoot(version int64, key []byte) error {
 	ndb.mtx.Lock()
 	defer ndb.mtx.Unlock()
-	return ndb.batch.Set(nodeKeyFormat.Key(GetRootKey(version)), legacyNodeKeyFormat.Key(key))
+	return ndb.batch.Set(legacyNodeKeyFormat.Key(GetRootKey(version)), legacyNodeKeyFormat.Key(key))
 }
 
 // Traverse fast nodes and return error if any, nil otherwise

--- a/nodedb.go
+++ b/nodedb.go
@@ -556,7 +556,6 @@ func (ndb *nodeDB) DeleteVersionsFrom(fromVersion int64) error {
 	err = ndb.traverseRange(nodeKeyPrefixFormat.KeyInt64(fromVersion), nodeKeyPrefixFormat.KeyInt64(latest+1), func(k, v []byte) error {
 		return ndb.batch.Delete(k)
 	})
-
 	if err != nil {
 		return err
 	}
@@ -1264,7 +1263,6 @@ func (ndb *nodeDB) String() (string, error) {
 		index++
 		return nil
 	})
-
 	if err != nil {
 		return "", err
 	}

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -52,12 +52,12 @@ func N(l, r interface{}) *Node {
 	if _, ok := l.(*Node); ok {
 		left = l.(*Node)
 	} else {
-		left = NewNode(i2b(l.(int)), nil)
+		left = NewNode(i2b(l.(int)), nil, false)
 	}
 	if _, ok := r.(*Node); ok {
 		right = r.(*Node)
 	} else {
-		right = NewNode(i2b(r.(int)), nil)
+		right = NewNode(i2b(r.(int)), nil, false)
 	}
 
 	n := &Node{


### PR DESCRIPTION
* For https://github.com/polymerdao/roadmap/issues/25
* On-top of the v1.1.2 version we use in monomer

This updates to be able to use the v0/legacy node db key format with the v1 interface. No impact on v1 support, it is still the default mode of operation and operates exactly as before.

Additionally, as with [v0](https://github.com/polymerdao/iavl/pull/1), there were two other things that needed to be adjusted to support pure preimage queries
1. To lookup the root hash by version (block height), which is then used to retrieve the root node. We need to instead provide the roothash directly, a method is introduced for loading a tree in this manner. This will also require modification in the calling context of our FPP application logic.
2. To load the storage version value (a versioning of the database- not the block height- e.g. 1.1.0). We avoid this when working with a legacy tree.

Note that in our FPP we must also be sure to instantiate our mutable tree without a fastcache, as the fastcache uses non-preimage keys. 

These changes do not affect the underlying DB layout so will be compatible with the normal usage in our non-FPP application logic (Polymerase).